### PR TITLE
Fix leaking the userinfo in the path properties

### DIFF
--- a/PerformanceBezier.xcodeproj/project.pbxproj
+++ b/PerformanceBezier.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = MM;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = "Milestone Made";
 				TargetAttributes = {
 					66B9D28B1A8D5FDE00CAC341 = {

--- a/PerformanceBezier/UIBezierPath+Util.m
+++ b/PerformanceBezier/UIBezierPath+Util.m
@@ -15,13 +15,7 @@
 @implementation UIBezierPath (Util)
 
 - (NSMutableDictionary *)userInfo {
-    UIBezierPathProperties *props = [self pathProperties];
-
-    if (!props.userInfo) {
-        props.userInfo = [[NSMutableDictionary alloc] init];
-    }
-
-    return props.userInfo;
+    return [self pathProperties].userInfo;
 }
 
 /// Returns a new empty path with the same properties `lineWidth`, `lineJoinStyle`, etc as this path

--- a/PerformanceBezier/UIBezierPathProperties.m
+++ b/PerformanceBezier/UIBezierPathProperties.m
@@ -104,6 +104,14 @@ typedef struct LengthCacheItem {
     [aCoder encodeInteger:cachedElementCount forKey:@"pathProperties_cachedElementCount"];
 }
 
+- (NSMutableDictionary *)userInfo {
+    if (!_userInfo) {
+        _userInfo = [[NSMutableDictionary alloc] init];
+    }
+
+    return _userInfo;
+}
+
 // for some reason the iPad 1 on iOS 5 needs to have this
 // method coded and not synthesized.
 - (void)setBezierPathByFlatteningPath:(UIBezierPath *)_bezierPathByFlatteningPath
@@ -119,6 +127,9 @@ typedef struct LengthCacheItem {
 {
     [bezierPathByFlatteningPath release];
     bezierPathByFlatteningPath = nil;
+
+    [_userInfo release];
+    _userInfo = nil;
     
     @synchronized (lock) {
         if (lengthCacheCount > 0 && elementLengthCache){


### PR DESCRIPTION
the `userInfo` dictionary is leaking the path properties. it was being set in Util.m, but the memory management is different for `PathProperties` than it is in that file